### PR TITLE
Add docker image name parameter to re-usable workflow

### DIFF
--- a/.github/workflows/build-and-publish-container-image.yml
+++ b/.github/workflows/build-and-publish-container-image.yml
@@ -13,6 +13,7 @@ on:
         default: "Dockerfile"
       docker-image-name:
         type: "string"
+        # TODO: Calculate NSIDC org name from variable?
         default: "nsidc/${{ github.event.repository.name }}"
     secrets:
       DOCKER_USER:

--- a/.github/workflows/build-and-publish-container-image.yml
+++ b/.github/workflows/build-and-publish-container-image.yml
@@ -11,6 +11,9 @@ on:
       docker-file-name:
         type: "string"
         default: "Dockerfile"
+      docker-image-name:
+        type: "string"
+        default: "nsidc/${{ github.event.repository.name }}"
     secrets:
       DOCKER_USER:
         required: true
@@ -24,7 +27,7 @@ jobs:
     name: "Build and release container image"
     runs-on: "ubuntu-latest"
     env:
-      IMAGE_NAME: "nsidc/${{ github.event.repository.name }}"
+      IMAGE_NAME: "${{ inputs.docker-image-name }}"
       # GitHub Actions expressions don't have great conditional support, so
       # writing a ternary expression looks a lot like bash. In Python, this
       # would read as:


### PR DESCRIPTION
I forgot that if I'm building two docker images I should probably publish them under two different names :laughing: 

:clown_face: 